### PR TITLE
Fix for Issue #64

### DIFF
--- a/src/utils/cliques.ts
+++ b/src/utils/cliques.ts
@@ -8,20 +8,15 @@ import {
 import {
   all,
   always,
-  assoc,
   curry,
-  divide,
   equals,
   filter,
   head,
   identity,
   ifElse,
   intersection,
-  isNil,
   keys,
   length,
-  map,
-  mapObjIndexed,
   minBy,
   pipe,
   pluck,
@@ -79,7 +74,7 @@ const checkPotentialByNodes = curry((nodes: ICombinations, potential: ICliquePot
       const whenValue = when[nodeId]
       const nodeValue = nodes[nodeId]
 
-      return isNil(nodeValue) || whenValue === nodeValue
+      return nodeValue == null || whenValue === nodeValue
     },
     keys(when),
   )
@@ -91,12 +86,19 @@ export const filterCliquePotentialsByNodeCombinations = (potentials: ICliquePote
     potentials,
   )
 
-export const normalizeCliquePotentials = (cliquesPotentials: ICliquePotentials) =>
-  mapObjIndexed(
-    (potentials) =>
-      map(
-        potential => assoc('then', divide(potential.then, sumCliquePotentials(potentials)), potential),
-        potentials,
-      ),
-    cliquesPotentials,
+export const normalizeCliquePotential = (potentials: ICliquePotentialItem[]) => {
+  const total = sumCliquePotentials(potentials)
+  return potentials.map(potential => {
+    potential.then = potential.then / total
+    return potential
+  },
   )
+}
+
+export const normalizeCliquePotentials = (cliquesPotentials: ICliquePotentials) => {
+  for (const key of Object.keys(cliquesPotentials)) {
+    cliquesPotentials[key] = normalizeCliquePotential(cliquesPotentials[key])
+  }
+
+  return cliquesPotentials
+}

--- a/test/graphs/moral.test.ts
+++ b/test/graphs/moral.test.ts
@@ -1,6 +1,10 @@
 import { createGraphBuilder, createMoralGraph } from '../../src/graphs'
+import { createNetwork } from '../../src/utils'
+import { allNodes as hugeNetworkAllNodes } from '../../models/huge-network'
 
 import { INode } from '../../src'
+const hugeNetwork = createNetwork(...hugeNetworkAllNodes)
+const hugeGraph = createGraphBuilder(hugeNetwork)
 
 const nodeA: INode = {
   id: 'A',
@@ -94,5 +98,14 @@ describe('Moral Graph', () => {
     const moralGraph = createMoralGraph(graph)
 
     expect(moralGraph.hasEdge('E', 'D')).toBeTruthy()
+  })
+})
+
+describe('Moral of huge network graph', () => {
+  it('has 53 more connections (edges) than the original graph', () => {
+    const moralGraph = createMoralGraph(hugeGraph)
+    const moralGraphEdges = moralGraph.getEdges()
+
+    expect(moralGraphEdges.length - hugeGraph.getEdges().length).toBe(53)
   })
 })

--- a/test/graphs/triangulated.test.ts
+++ b/test/graphs/triangulated.test.ts
@@ -1,6 +1,12 @@
-import { createTriangulatedGraph as buildTriangulatedGraph, createGraphBuilder } from '../../src/graphs'
+import { createTriangulatedGraph as buildTriangulatedGraph, createGraphBuilder, createMoralGraph } from '../../src/graphs'
+import { createNetwork } from '../../src/utils'
+import { allNodes as hugeNetworkAllNodes } from '../../models/huge-network'
 
 import { INode } from '../../src'
+
+const hugeNetwork = createNetwork(...hugeNetworkAllNodes)
+const hugeGraph = createGraphBuilder(hugeNetwork)
+const moralizedHugeGraph = createMoralGraph(hugeGraph)
 
 const nodeA: INode = {
   id: 'A',
@@ -112,5 +118,15 @@ describe('Triangulated Graph', () => {
     const triangulatedGraph = createTriangulatedGraph()
 
     expect(triangulatedGraph.hasEdge('D', 'C')).toBeTruthy()
+  })
+})
+
+describe('Triangulated moral graph of huge network graph', () => {
+  it('has 83 more connections (edges) than the original graph', () => {
+    const triangulatedGraph = buildTriangulatedGraph(moralizedHugeGraph)
+    const moralizedGraphEdges = moralizedHugeGraph.getEdges().map(x => x.sort())
+    const triangulatedGraphEdges = triangulatedGraph.getEdges().map(x => x.sort())
+
+    expect(triangulatedGraphEdges).toEqual(moralizedGraphEdges)
   })
 })

--- a/test/infers/consistency.test.ts
+++ b/test/infers/consistency.test.ts
@@ -1,0 +1,86 @@
+'use strict'
+import * as expect from 'expect'
+
+import { allNodes } from '../../models/huge-network'
+import { createNetwork, normalizeCliquePotential } from '../../src/utils'
+import createCliques from '../../src/inferences/junctionTree/create-cliques'
+import getCliquesPotentials from '../../src/inferences/junctionTree/get-cliques-potentials'
+import { findSepSetWithCliques, marginalizePotentials } from '../../src/inferences/junctionTree/propagate-potentials'
+import { ICliquePotentialItem } from '../../src'
+
+/** After message passing between the potentials in the junciton tree, each clique potential for any
+ * two adjacent cliques must be consistent.   Specifically, when they are marginalized over the
+ * set of variables in their mutual separation set, the the marginals should be equivalent.   This
+ * test verifies the consistency property for the huge-network junction tree.
+ *
+ * Note: In order to account for floating point rounding differences between each pair of
+ * clique potentials, we adjust them to a precision of 4 decimal points in the significand of the
+ * range of the potential.
+*/
+
+// process the network to construct junction tree, cliques and their potentials
+const network = createNetwork(...allNodes)
+const { cliques, sepSets, junctionTree } = createCliques(network)
+
+const cliquesPotentials = getCliquesPotentials(cliques, network, junctionTree, sepSets, {})
+
+// construct the list of pairs in the junction tree by traversal of nodes in depth first
+// topological sorting order rooted on the first clique, returning a list of string pairs
+// representing the identifiers of two adjacent cliques
+function makePairs (id: string, parentId?: string): { src: string; trg: string }[] {
+  const neighbors = junctionTree.getNodeEdges(id)
+  const outArcs = []
+  for (const neighbor of neighbors) {
+    if (parentId && neighbor === parentId) continue
+    outArcs.push({ src: id, trg: neighbor })
+    outArcs.push(...makePairs(neighbor, id))
+  }
+  return outArcs
+}
+
+const pairs: { src: string; trg: string }[] = makePairs('0')
+
+// construct the list of tests to perform.   For each pair of adjacent cliques,
+// verify that their marginalized potentials are equivalent up to the specified
+// precision.
+const tests = pairs.map(pair =>
+  ({
+    name: `cliques ${pair.src} and ${pair.trg}`,
+    fn: () => {
+      // look up the clique potentials for the two adjacent cliques and get their separation set.
+      const srcPotential: ICliquePotentialItem[] = cliquesPotentials[pair.src]
+      const trgPotential: ICliquePotentialItem[] = cliquesPotentials[pair.trg]
+      const mSepSet = findSepSetWithCliques(pair.src, pair.trg, sepSets)
+
+      // if their separation set does not exist then exit
+      expect('mSepSet').toBeTruthy()
+
+      if (!mSepSet) return
+
+      // construct the marginalized potentials for each clique and restrict to the specified
+      // precision.
+      const toPrecision = (xs: ICliquePotentialItem[], precision: number): ICliquePotentialItem[] =>
+        xs.map((x: ICliquePotentialItem) => {
+          const { when } = x
+          const then: number = parseFloat(x.then.toPrecision(precision))
+          return { when, then }
+        })
+
+      const sepSet = mSepSet.sharedNodes.sort()
+      const srcPotentialMarginalized = toPrecision(normalizeCliquePotential(marginalizePotentials(network, sepSet, srcPotential)), 4)
+      const trgPotentialMarginalized = toPrecision(normalizeCliquePotential(marginalizePotentials(network, sepSet, trgPotential)), 4)
+
+      // We expect that the marginalized potentials are equivalent up to the specified
+      // precision.
+      expect(srcPotentialMarginalized).toEqual(trgPotentialMarginalized)
+    },
+  }),
+)
+
+describe('infers', () => {
+  describe('hugeNetwork cliques', () => {
+    for (const test of tests) {
+      it(`The potentials for ${test.name} are consistent`, test.fn)
+    }
+  })
+})

--- a/test/utils/create-cliques.test.ts
+++ b/test/utils/create-cliques.test.ts
@@ -1,6 +1,10 @@
 import { INode } from '../../src'
 import { createCliques as buildCliques } from '../../src/utils/create-cliques'
+import { createNetwork } from '../../src/utils'
 import { createGraphBuilder } from '../../src/graphs'
+import createJTreeCliques from '../../src/inferences/junctionTree/create-cliques'
+import { allNodes as hugeNetworkAllNodes } from '../../models/huge-network'
+const hugeNetwork = createNetwork(...hugeNetworkAllNodes)
 
 const nodeA: INode = {
   id: 'A',
@@ -124,5 +128,47 @@ describe('Create Cliques Utils', () => {
 
       expect(clique.nodeIds).toEqual(['F', 'D', 'E'])
     })
+  })
+})
+
+const { cliques: hugeNetCliques } = createJTreeCliques(hugeNetwork)
+const expectedCliques = [
+  ['node1', 'node13', 'node16', 'node17', 'node24', 'node25', 'node37'],
+  ['node1', 'node24', 'node31'],
+  ['node1', 'node24', 'node32'],
+  ['node1', 'node24', 'node33'],
+  ['node1', 'node24', 'node34'],
+  ['node1', 'node24', 'node35'],
+  ['node2', 'node3', 'node4', 'node5', 'node6', 'node7', 'node8', 'node9'],
+  ['node2', 'node10', 'node38'],
+  ['node10', 'node11', 'node12'],
+  ['node13', 'node14', 'node15'],
+  ['node13', 'node16', 'node17', 'node25', 'node36', 'node37'],
+  ['node17', 'node18', 'node23'],
+  ['node18', 'node19', 'node20', 'node21', 'node22'],
+  ['node25', 'node26', 'node27', 'node28', 'node29', 'node30'],
+  ['node37', 'node38', 'node39'],
+].map(x => x.sort()).sort()
+
+describe('Huge Network', () => {
+  it('has 15 cliques', () => {
+    const foundCliques = hugeNetCliques.map(x => x.nodeIds.sort()).sort()
+    expect(foundCliques[0]).toEqual(expectedCliques[0])
+    expect(foundCliques[1]).toEqual(expectedCliques[1])
+    expect(foundCliques[2]).toEqual(expectedCliques[2])
+    expect(foundCliques[3]).toEqual(expectedCliques[3])
+    expect(foundCliques[4]).toEqual(expectedCliques[4])
+    expect(foundCliques[5]).toEqual(expectedCliques[5])
+    expect(foundCliques[6]).toEqual(expectedCliques[6])
+    expect(foundCliques[7]).toEqual(expectedCliques[7])
+    expect(foundCliques[8]).toEqual(expectedCliques[8])
+    expect(foundCliques[9]).toEqual(expectedCliques[9])
+    expect(foundCliques[10]).toEqual(expectedCliques[10])
+    expect(foundCliques[11]).toEqual(expectedCliques[11])
+    expect(foundCliques[12]).toEqual(expectedCliques[12])
+    expect(foundCliques[13]).toEqual(expectedCliques[13])
+    expect(foundCliques[14]).toEqual(expectedCliques[14])
+    expect(foundCliques[15]).toEqual(expectedCliques[15])
+    expect(hugeNetCliques.length).toBe(15)
   })
 })

--- a/test/utils/create-sepsets.test.ts
+++ b/test/utils/create-sepsets.test.ts
@@ -1,6 +1,18 @@
 import { IClique } from '../../src'
 import { createSepSets } from '../../src/utils'
 
+// This colleciton of cliques comes from a moralized, triangularized netowrk with the
+// following topology:
+
+// A --- C --- F
+// |   / | \   |
+// | /   |   \ |
+// B --- D --- E
+
+// It should have a junction tree equivalent up to factor ordering to the following:
+
+//           { B,C }           { C,D }           { D,E }
+// { A,B,C } ------- { B,C,D } ------- { C,D,E } ------ { D,E,F }
 const cliques: IClique[] = [
   { id: '0', nodeIds: ['C', 'E', 'D'] },
   { id: '1', nodeIds: ['C', 'B', 'A'] },
@@ -16,33 +28,29 @@ describe('Create SepSets Utils', () => {
   })
 
   it('calls "onRemove" function twice', () => {
+    // the fully connected clique graph will have three nodes of cardinality 2,
+    // and two nodes where the separationSet has cardinality of 1.   It also will
+    // have two cycles:
+    //          { C }
+    //      (1) ----- (0)
+    //       |      /  |
+    // {C,B} |{C,D}/   | {D,E}
+    //       |  /      |
+    //      (2) ----- (3)
+    //          { D }
+
+    // In order to construct a maximal spanning tree with the running intersection
+    // property, two separation sets must be removed, {C} and {D}
     const onRemove = jest.fn()
     createSepSets(cliques, onRemove)
 
     expect(onRemove).toHaveBeenCalledTimes(2)
-    expect(onRemove).toHaveBeenNthCalledWith(1, '1', '2')
+    expect(onRemove).toHaveBeenNthCalledWith(1, '0', '1')
     expect(onRemove).toHaveBeenNthCalledWith(2, '2', '3')
   })
 
   describe('Where the first sepset', () => {
     const getSepSet = () => createSepSets(cliques, jest.fn())[0]
-
-    it('connects clique "0" and "1"', () => {
-      const sepSet = getSepSet()
-
-      expect(sepSet.ca).toBe('0')
-      expect(sepSet.cb).toBe('1')
-    })
-
-    it('has 1 shared nodes ("C")', () => {
-      const sepSet = getSepSet()
-
-      expect(sepSet.sharedNodes).toEqual(['C'])
-    })
-  })
-
-  describe('Where the second sepset', () => {
-    const getSepSet = () => createSepSets(cliques, jest.fn())[1]
 
     it('connects clique "0" and "2"', () => {
       const sepSet = getSepSet()
@@ -51,27 +59,44 @@ describe('Create SepSets Utils', () => {
       expect(sepSet.cb).toBe('2')
     })
 
-    it('has 2 shared nodes ("C", "D")', () => {
+    it('has 2 shared nodes ("C","D")', () => {
       const sepSet = getSepSet()
 
-      expect(sepSet.sharedNodes).toEqual(['C', 'D'])
+      expect(sepSet.sharedNodes.sort()).toEqual(['C', 'D'])
     })
   })
 
-  describe('Where the third sepset', () => {
-    const getSepSet = () => createSepSets(cliques, jest.fn())[2]
+  describe('Where the second sepset', () => {
+    const getSepSet = () => createSepSets(cliques, jest.fn())[1]
 
-    it('connects clique "0" and "2"', () => {
+    it('connects clique "0" and "3"', () => {
       const sepSet = getSepSet()
 
       expect(sepSet.ca).toBe('0')
       expect(sepSet.cb).toBe('3')
     })
 
-    it('has 2 shared nodes ("E", "D")', () => {
+    it('has 2 shared nodes ("D", "E")', () => {
       const sepSet = getSepSet()
 
-      expect(sepSet.sharedNodes).toEqual(['E', 'D'])
+      expect(sepSet.sharedNodes.sort()).toEqual(['D', 'E'])
+    })
+  })
+
+  describe('Where the third sepset', () => {
+    const getSepSet = () => createSepSets(cliques, jest.fn())[2]
+
+    it('connects clique "1" and "2"', () => {
+      const sepSet = getSepSet()
+
+      expect(sepSet.ca).toBe('1')
+      expect(sepSet.cb).toBe('2')
+    })
+
+    it('has 2 shared nodes ("C", "B")', () => {
+      const sepSet = getSepSet()
+
+      expect(sepSet.sharedNodes.sort()).toEqual(['B', 'C'])
     })
   })
 })


### PR DESCRIPTION
#### What does this PR do?

This pull request addresses an issue which causes junction tree inference to return the wrong probabilities for some network topologies.   In short:

* The junction tree diagram is creating unnecessary edges during triangularization 
* The spanning tree for the clique graph is creating the smallest, rather than the largest separation sets
* The intersection between cliques to determine the membership of the separation sets failed to identify all members 

These bugs have been fixed as well as some minor performance improvements.   A more detailed description follows:

* Junction tree construction
  - Ignore creation of simplicial nodes during graph triangulation.  This has no impact on accuracy, only on performance.
  - Fix the running intersection property of junction trees.   Previously the spanning tree found the smallest non-empty separation sets between cliques instead of the largest.
* create-initial-potentials
  - createFactorForClique: fixed so that each factor is included in only one clique.   This is required to faithfully implement the Huggin algorithm.
  - createICliqueFactors: fixed so that each factor is preferentially added to the clique with the smallest number of nodes.   This is required to ensure that inference consistently picks the correct node to use when inferring the joint probabilities.
  - getPotentialValueForNode: Added explicit type signature so that tests would compile.
  - createCliquePotential - Added explicit type signature so that tests would compile.
  - default export - replaced reduce with for loop to avoid deep-copy of assoc function called in each pass of reduce.   It is likely that the reduce/assoc pattern is used elsewhere; consider replacing to improve performance.
* propagate-potentials
  - hasSepSetCliques: added explicit type signature
  - findSepSetsWithCliques: added explicit type signature
  - getSepSetsForCliques: removed fruitless test for non-parent nodes.
  - Refactored all the message passing/graph traversal to eliminate unnecessary graph traversals, to factor out common code, and ensure agreement
    with Hugin algorithm.
* utils/cliques
  - refactored normalization to avoid repeated calls to summation function inside each iteration of the map function.  Performance only.
* utils/create-sepsets
  - refactored getShared nodes.   Reduces computation complexity and fixes error where the separation set for cliques 8 and 9 in the huge graph
    did not include node 16.
* tests
  - added moral graph test for huge network
  - added triangulated graph test for huge network
  - added a new test to ensure consistency property for potentials of the huge network
  - added clique tests for huge network

#### Where should the reviewer start?
The most important changes are in the in the functions "getSharedNodes", "findSimplicialNodes", "sepSetCompare", and the "propagate-potentials" module.   

#### What testing has been done on this PR?
I have added additional unit tests to verify the correctness of the code.  

#### How should this be manually tested?
If you have other bayes networks that you have used for testing in the past, you may want to try them with the new code.   

#### Any background context you want to provide?

#### What are the relevant issues?
Issue #64

#### Screenshots (if appropriate)
