### PR TITLE
Fix for issue #67

### DIFF
--- a/src/inferences/junctionTree/propagate-potentials.ts
+++ b/src/inferences/junctionTree/propagate-potentials.ts
@@ -16,7 +16,6 @@ import {
   divide,
   equals,
   find,
-  head,
   keys,
   map,
   multiply,
@@ -31,6 +30,7 @@ import {
   buildCombinations,
   objectEqualsByFirstObjectKeys,
 } from '../../utils'
+import { getConnectedComponents } from '../../utils/connected-components'
 
 interface ICollectEvidenceOrder {
   id: string;
@@ -127,11 +127,6 @@ const absorbMessage = (potentials: ICliquePotentialItem[], messagePotentials: IC
   )
 }
 
-/** * Collect the evidence a the first element in the list of cliques.   Efficiency of the
- * evidence collection assumes that the cliques are in topological sorted order.
- */
-const bestCliqueRoot: (cliques: IClique[]) => IClique = head
-
 const passMessage = (network: INetwork, sepSets: ISepSet[], cliquesPotentials: ICliquePotentials, separatorPotentials: ICliquePotentialMessages, src: string, trg: string) => {
   const i = (src < trg) ? src : trg
   const j = (src < trg) ? trg : src
@@ -186,12 +181,18 @@ const distributeCliquesEvidence = (network: INetwork, junctionTree: IGraph, sepS
 export default (network: INetwork, junctionTree: IGraph, cliques: IClique[], sepSets: ISepSet[], cliquesPotentials: ICliquePotentials): ICliquePotentials => {
   // Create a store for the messages passed between cliques.   Initially this store is empty because no messages have been passed.
   const messages: ICliquePotentialMessages = createMessagesByCliques(cliques)
-  const rootId: string = bestCliqueRoot(cliques).id
+  const ccs: string[][] = getConnectedComponents(junctionTree)
+  let potentials = cliquesPotentials
 
-  // Update the potentials starting at the leaf nodes and moving to the roots
-  const collectedCliquesPotentials = collectCliquesEvidence(network, junctionTree, sepSets, messages, cliquesPotentials, rootId)
-  // Update the potentials starting at the root node and moving toward the leaves
-  const distributedCliquesPotentials = distributeCliquesEvidence(network, junctionTree, sepSets, messages, collectedCliquesPotentials, rootId)
+  // Make each connected component of the factor graph consistent.    This is not strictly necessary for a well formed Bayes net
+  // which should have single connected component, however during incremental construction or structural learning, networks which
+  // are forests, rather than trees may occur.
+  for (const [rootId] of ccs) {
+    // Update the potentials starting at the leaf nodes and moving to the roots
+    const collectedCliquesPotentials = collectCliquesEvidence(network, junctionTree, sepSets, messages, potentials, rootId)
+    // Update the potentials starting at the root node and moving toward the leaves
+    potentials = distributeCliquesEvidence(network, junctionTree, sepSets, messages, collectedCliquesPotentials, rootId)
+  }
 
-  return distributedCliquesPotentials
+  return potentials
 }

--- a/src/utils/connected-components.ts
+++ b/src/utils/connected-components.ts
@@ -1,0 +1,30 @@
+import { IGraph } from '..'
+
+/** Find the connected components of the clique graph.  Complexity is on the
+ * order O(n m) where n is the number of cliques and m is the number of separation
+ * sets.   This complexity could be reduced to n (log m) by using a more efficient
+ * means of finding
+ */
+export const getConnectedComponents = (junctionTree: IGraph) => {
+  const ids: string[] = junctionTree.getNodesId()
+  const visited: Set<string> = new Set<string>()
+  const ccs = []
+
+  const process = (id: string): string[] => {
+    const result = [id]
+    visited.add(id)
+    const neighbors = junctionTree.getNodeEdges(id).filter((z: string) => !visited.has(z))
+
+    for (const neighbor of neighbors) {
+      result.push(...process(neighbor))
+    }
+
+    return result
+  }
+
+  for (const id of ids) {
+    if (!visited.has(id)) ccs.push(process(id))
+  }
+
+  return ccs
+}

--- a/src/utils/connected-components.ts
+++ b/src/utils/connected-components.ts
@@ -1,4 +1,5 @@
 import { IGraph } from '..'
+import { reduce } from 'ramda'
 
 /** Find the connected components of the clique graph.  Complexity is on the
  * order O(n m) where n is the number of cliques and m is the number of separation
@@ -11,15 +12,19 @@ export const getConnectedComponents = (junctionTree: IGraph) => {
   const ccs = []
 
   const process = (id: string): string[] => {
-    const result = [id]
+    const neighbors = junctionTree.getNodeEdges(id)
+    const notVisitedNeighbors = neighbors.filter((z: string) => !visited.has(z))
+
     visited.add(id)
-    const neighbors = junctionTree.getNodeEdges(id).filter((z: string) => !visited.has(z))
 
-    for (const neighbor of neighbors) {
-      result.push(...process(neighbor))
-    }
-
-    return result
+    return reduce(
+      (result, neighbor) => {
+        result.push(...process(neighbor))
+        return result
+      },
+      [id],
+      notVisitedNeighbors,
+    )
   }
 
   for (const id of ids) {

--- a/test/infers/two-connected-components.test.ts
+++ b/test/infers/two-connected-components.test.ts
@@ -1,0 +1,185 @@
+import * as expect from 'expect'
+
+import { IInfer, INode } from '../../src/types'
+import { createNetwork } from '../../src/utils'
+import { inferences } from '../../src'
+
+const {
+  enumeration,
+  junctionTree,
+  variableElimination,
+} = inferences
+
+/* This test confirms that the junction tree inference algorithm produces
+the correct results when the Bayesian network consists of more than one
+connected component.   This test uses the following network:
+
+   A      a
+  / \    / \
+ B   C  b   c
+
+ where B and C are conditioned on A, and b and c are conditioned upon a.
+ As originally implemented, the HUGIN algorithm performs message passing
+ only for the connected component containing {A,B,C}, producing incorrect
+ inferences for c.
+*/
+
+const nodes: INode[] = [
+  {
+    id: 'A',
+    states: ['T', 'F'],
+    parents: [],
+    cpt: { T: 0.9, F: 0.1 },
+  },
+  {
+    id: 'a',
+    states: ['T', 'F'],
+    parents: [],
+    cpt: { T: 0.9, F: 0.1 },
+  },
+  {
+    id: 'B',
+    states: ['T', 'F'],
+    parents: ['A'],
+    cpt: [
+      { when: { A: 'T' }, then: { T: 0.9, F: 0.1 } },
+      { when: { A: 'F' }, then: { T: 0.1, F: 0.9 } },
+    ],
+  },
+  {
+    id: 'C',
+    states: ['T', 'F'],
+    parents: ['A'],
+    cpt: [
+      { when: { A: 'T' }, then: { T: 0.9, F: 0.1 } },
+      { when: { A: 'F' }, then: { T: 0.1, F: 0.9 } },
+    ],
+  },
+  {
+    id: 'b',
+    states: ['T', 'F'],
+    parents: ['a'],
+    cpt: [
+      { when: { a: 'T' }, then: { T: 0.9, F: 0.1 } },
+      { when: { a: 'F' }, then: { T: 0.1, F: 0.9 } },
+    ],
+  },
+  {
+    id: 'c',
+    states: ['T', 'F'],
+    parents: ['a'],
+    cpt: [
+      { when: { a: 'T' }, then: { T: 0.9, F: 0.1 } },
+      { when: { a: 'F' }, then: { T: 0.1, F: 0.9 } },
+    ],
+  },
+]
+
+const network = createNetwork(...nodes)
+const infersGiveNothing = (infer: IInfer) => {
+  const given = {}
+
+  expect(infer(network, { A: 'T' }, given).toFixed(4)).toBe('0.9000')
+  expect(infer(network, { A: 'F' }, given).toFixed(4)).toBe('0.1000')
+  expect(infer(network, { B: 'T' }, given).toFixed(4)).toBe('0.8200')
+  expect(infer(network, { B: 'F' }, given).toFixed(4)).toBe('0.1800')
+  expect(infer(network, { C: 'T' }, given).toFixed(4)).toBe('0.8200')
+  expect(infer(network, { C: 'F' }, given).toFixed(4)).toBe('0.1800')
+  expect(infer(network, { a: 'T' }, given).toFixed(4)).toBe('0.9000')
+  expect(infer(network, { a: 'F' }, given).toFixed(4)).toBe('0.1000')
+  expect(infer(network, { b: 'T' }, given).toFixed(4)).toBe('0.8200')
+  expect(infer(network, { b: 'F' }, given).toFixed(4)).toBe('0.1800')
+  expect(infer(network, { c: 'T' }, given).toFixed(4)).toBe('0.8200')
+  expect(infer(network, { c: 'F' }, given).toFixed(4)).toBe('0.1800')
+}
+
+const infersGiveAFalse = (infer: IInfer) => {
+  const given = { A: 'F' }
+
+  expect(infer(network, { B: 'T' }, given).toFixed(4)).toBe('0.1000')
+  expect(infer(network, { B: 'F' }, given).toFixed(4)).toBe('0.9000')
+  expect(infer(network, { C: 'T' }, given).toFixed(4)).toBe('0.1000')
+  expect(infer(network, { C: 'F' }, given).toFixed(4)).toBe('0.9000')
+  expect(infer(network, { a: 'T' }, given).toFixed(4)).toBe('0.9000')
+  expect(infer(network, { a: 'F' }, given).toFixed(4)).toBe('0.1000')
+  expect(infer(network, { b: 'T' }, given).toFixed(4)).toBe('0.8200')
+  expect(infer(network, { b: 'F' }, given).toFixed(4)).toBe('0.1800')
+  expect(infer(network, { c: 'T' }, given).toFixed(4)).toBe('0.8200')
+  expect(infer(network, { c: 'F' }, given).toFixed(4)).toBe('0.1800')
+}
+
+const infersGiveATrue = (infer: IInfer) => {
+  const given = { A: 'T' }
+
+  expect(infer(network, { B: 'T' }, given).toFixed(4)).toBe('0.9000')
+  expect(infer(network, { B: 'F' }, given).toFixed(4)).toBe('0.1000')
+  expect(infer(network, { C: 'T' }, given).toFixed(4)).toBe('0.9000')
+  expect(infer(network, { C: 'F' }, given).toFixed(4)).toBe('0.1000')
+  expect(infer(network, { a: 'T' }, given).toFixed(4)).toBe('0.9000')
+  expect(infer(network, { a: 'F' }, given).toFixed(4)).toBe('0.1000')
+  expect(infer(network, { b: 'T' }, given).toFixed(4)).toBe('0.8200')
+  expect(infer(network, { b: 'F' }, given).toFixed(4)).toBe('0.1800')
+  expect(infer(network, { c: 'T' }, given).toFixed(4)).toBe('0.8200')
+  expect(infer(network, { c: 'F' }, given).toFixed(4)).toBe('0.1800')
+}
+
+const infersGiveaFalse = (infer: IInfer) => {
+  const given = { a: 'T' }
+
+  expect(infer(network, { b: 'T' }, given).toFixed(4)).toBe('0.9000')
+  expect(infer(network, { b: 'F' }, given).toFixed(4)).toBe('0.1000')
+  expect(infer(network, { c: 'T' }, given).toFixed(4)).toBe('0.9000')
+  expect(infer(network, { c: 'F' }, given).toFixed(4)).toBe('0.1000')
+  expect(infer(network, { A: 'T' }, given).toFixed(4)).toBe('0.9000')
+  expect(infer(network, { A: 'F' }, given).toFixed(4)).toBe('0.1000')
+  expect(infer(network, { B: 'T' }, given).toFixed(4)).toBe('0.8200')
+  expect(infer(network, { B: 'F' }, given).toFixed(4)).toBe('0.1800')
+  expect(infer(network, { C: 'T' }, given).toFixed(4)).toBe('0.8200')
+  expect(infer(network, { C: 'F' }, given).toFixed(4)).toBe('0.1800')
+}
+
+const infersGiveaTrue = (infer: IInfer) => {
+  const given = { a: 'F' }
+
+  expect(infer(network, { b: 'T' }, given).toFixed(4)).toBe('0.1000')
+  expect(infer(network, { b: 'F' }, given).toFixed(4)).toBe('0.9000')
+  expect(infer(network, { c: 'T' }, given).toFixed(4)).toBe('0.1000')
+  expect(infer(network, { c: 'F' }, given).toFixed(4)).toBe('0.9000')
+  expect(infer(network, { A: 'T' }, given).toFixed(4)).toBe('0.9000')
+  expect(infer(network, { A: 'F' }, given).toFixed(4)).toBe('0.1000')
+  expect(infer(network, { B: 'T' }, given).toFixed(4)).toBe('0.8200')
+  expect(infer(network, { B: 'F' }, given).toFixed(4)).toBe('0.1800')
+  expect(infer(network, { C: 'T' }, given).toFixed(4)).toBe('0.8200')
+  expect(infer(network, { C: 'F' }, given).toFixed(4)).toBe('0.1800')
+}
+
+const inferencesNames: { [key: string]: IInfer } = {
+  Enumeration: enumeration.infer,
+  'Junction Tree': junctionTree.infer,
+  'Variable Elimination': variableElimination.infer,
+}
+
+const tests: { [key: string]: (infer: IInfer) => void } = {
+  'infers give nothing': infersGiveNothing,
+  'infers give A False': infersGiveAFalse,
+  'infers give A True': infersGiveATrue,
+  'infers give a False': infersGiveaFalse,
+  'infers give a True': infersGiveaTrue,
+}
+
+describe('infers', () => {
+  describe('two connected component network', () => {
+    const testNames = Object.keys(tests)
+    const inferNames = Object.keys(inferencesNames)
+
+    for (const testName of testNames) {
+      const method = tests[testName]
+
+      for (const inferName of inferNames) {
+        const infer = inferencesNames[inferName]
+
+        it(`${testName} (${inferName})`, () => method(infer))
+      }
+    }
+  })
+})

--- a/test/infers/two-connected-components.test.ts
+++ b/test/infers/two-connected-components.test.ts
@@ -17,7 +17,7 @@ connected component.   This test uses the following network:
    A      a
   / \    / \
  B   C  b   c
-
+s
  where B and C are conditioned on A, and b and c are conditioned upon a.
  As originally implemented, the HUGIN algorithm performs message passing
  only for the connected component containing {A,B,C}, producing incorrect


### PR DESCRIPTION
#### What does this PR do?
Fixes issue 67.   The standard HUGIN algorithm assumes the existence of a single spanning tree for the clique graph of the Bayesian network.   When the network consists of multiple connected components, this results in some portions of the graph not participating in message passing, and producing incorrect inferences.    This pull request extends the algorithm to traverse each connected component of the graph, thereby ensuring consistency and correct inferences.

#### Where should the reviewer start?
The most important change is to the propagate-potentials module.   It has been modified to find the connected components of the clique graph prior to performing message passing.   During message passing it uses the first node in each connected component as the root for the localized traversal.

#### What testing has been done on this PR?
Introduced a new test (two-connected-components) which tests junction tree inference in a graph containing two connected components.   Prior to this fix, the test failed.   After the fix, it passes.

#### How should this be manually tested?
No additional manual testing beyond what is normally performed

#### Any background context you want to provide?
NA

#### What are the relevant issues?
#67

#### Screenshots (if appropriate)
NA